### PR TITLE
Fix pagination, add per-page selector, editable descriptions, live run terminal

### DIFF
--- a/crontab/start.go
+++ b/crontab/start.go
@@ -45,7 +45,7 @@ func Start() error {
 	}
 
 	// start web dashboard
-	go startWeb(ctx, config.web.frontend)
+	go startWeb(ctx, config.web.frontend, config.crontab.scriptPath)
 
 	err = cron.Start()
 	if err != nil {
@@ -61,12 +61,12 @@ func Start() error {
 
 // startWeb launches the platform-based web server for the admin dashboard.
 // It runs in a goroutine and respects the parent context for shutdown.
-func startWeb(ctx context.Context, frontendPath string) {
+func startWeb(ctx context.Context, frontendPath, scriptPath string) {
 	opts := platform.NewOptions()
 	opts.ServerAddr = config.web.addr
 
 	svc := platform.New(opts)
-	svc.Register(web.NewModule(frontendPath))
+	svc.Register(web.NewModule(frontendPath, scriptPath))
 
 	if err := svc.Start(ctx); err != nil {
 		log.Printf("Web dashboard error: %+v", err)

--- a/frontend/assets/style.css
+++ b/frontend/assets/style.css
@@ -517,16 +517,19 @@ a:hover {
     color: #e2e8f0;
     font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.82rem;
-    line-height: 1.6;
+    line-height: 1.55;
     max-height: 60vh;
     overflow: auto;
     padding: 16px 18px;
-    white-space: pre-wrap;
+    white-space: normal;
     word-break: break-word;
 }
 
 .output-line {
-    padding: 1px 0;
+    display: block;
+    margin: 0;
+    padding: 0;
+    white-space: pre-wrap;
 }
 
 .output-line.stderr,
@@ -560,6 +563,160 @@ a:hover {
 
 .app-footer a {
     color: var(--muted);
+}
+
+/* ---------- Job name / description ---------- */
+.job-name__row {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+}
+
+.job-desc {
+    color: var(--muted);
+    font-size: 0.82rem;
+    font-weight: 400;
+    margin-top: 4px;
+    max-width: 42ch;
+}
+
+.icon-btn {
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    color: var(--muted-2);
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: center;
+    line-height: 1;
+    padding: 4px;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.icon-btn:hover {
+    background: var(--primary-soft);
+    color: var(--primary-600);
+}
+
+.icon-btn[aria-label="Close"] {
+    font-size: 1.4rem;
+    padding: 0 8px;
+}
+
+/* ---------- Pager info / page size ---------- */
+.pager {
+    flex-wrap: wrap;
+}
+
+.pager__info {
+    align-items: center;
+    color: var(--muted);
+    display: flex;
+    font-size: 0.85rem;
+    gap: 16px;
+}
+
+.pager__size {
+    align-items: center;
+    color: var(--muted);
+    display: flex;
+    font-size: 0.8rem;
+    gap: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.pager__size select {
+    flex: 0 0 auto;
+    min-width: 0;
+    padding: 6px 10px;
+    width: auto;
+}
+
+.btn.is-disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+/* ---------- Modal ---------- */
+.modal-overlay {
+    align-items: flex-start;
+    background: rgba(15, 23, 42, 0.55);
+    display: flex;
+    inset: 0;
+    justify-content: center;
+    padding: 6vh 16px;
+    position: fixed;
+    z-index: 200;
+}
+
+.modal-overlay[hidden] {
+    display: none;
+}
+
+.modal {
+    background: var(--surface);
+    border-radius: var(--radius);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    max-width: 520px;
+    overflow: hidden;
+    width: 100%;
+}
+
+.modal--wide {
+    max-width: 900px;
+}
+
+.modal__head {
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    font-weight: 650;
+    justify-content: space-between;
+    padding: 14px 18px;
+}
+
+.modal__head code {
+    background: var(--surface-2);
+    border-radius: 6px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85rem;
+    padding: 2px 6px;
+}
+
+.modal__body {
+    padding: 18px;
+}
+
+.modal__label {
+    color: var(--muted);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.82rem;
+    margin-bottom: 8px;
+}
+
+.modal__body textarea.form-control {
+    resize: vertical;
+    width: 100%;
+}
+
+.modal__foot {
+    border-top: 1px solid var(--border);
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    padding: 14px 18px;
+}
+
+.terminal-box {
+    background: #0b1120;
+    border-radius: var(--radius-sm);
+    min-height: 340px;
+    padding: 10px;
 }
 
 /* ---------- Responsive ---------- */

--- a/frontend/description.php
+++ b/frontend/description.php
@@ -1,0 +1,30 @@
+<?php
+
+// @route POST /description
+
+include("bootstrap.php");
+
+header("Content-Type: application/json");
+
+if (!isset($_POST["name"]) || !isset($_POST["description"])) {
+	echo json_encode(array("ok" => false, "err" => "Missing name or description"));
+	$db->close();
+	exit;
+}
+
+$name = $_POST["name"];
+$description = $_POST["description"];
+
+$job = $db->get("SELECT name FROM jobs WHERE name = ?", $name);
+if (!$job) {
+	echo json_encode(array("ok" => false, "err" => "Job not found"));
+	$db->close();
+	exit;
+}
+
+$now = date("Y-m-d H:i:s");
+$db->query("UPDATE jobs SET description = ?, updated_at = ? WHERE name = ?", $description, $now, $name);
+
+echo json_encode(array("ok" => true, "name" => $name, "description" => $description));
+
+$db->close();

--- a/frontend/detail.php
+++ b/frontend/detail.php
@@ -6,7 +6,7 @@
 include("bootstrap.php");
 
 $jobName = route_job_name();
-$ID = $_PATH["ID"] + 0;
+$ID = (int)$_PATH["ID"];
 
 $row = $db->get("SELECT output FROM (SELECT ROW_NUMBER() OVER (ORDER BY stamp DESC) AS ID, output FROM logs WHERE name = ?) WHERE ID = ?", $jobName, $ID);
 

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -8,30 +8,58 @@ if (isset($_PATH["jobName"]) && $_PATH["jobName"] != "") {
 	$jobName = $_PATH["jobName"];
 	$pageNumber = 0;
 	if (isset($_GET["pageNumber"])) {
-		$pageNumber = $_GET["pageNumber"] + 0;
+		$pageNumber = (int)$_GET["pageNumber"];
 	}
-	$pageSize = 25;
+	if ($pageNumber < 0) {
+		$pageNumber = 0;
+	}
+
+	$pageSize = 20;
+	if (isset($_GET["pageSize"])) {
+		$requested = (int)$_GET["pageSize"];
+		if ($requested == 50) {
+			$pageSize = 50;
+		}
+		if ($requested == 100) {
+			$pageSize = 100;
+		}
+	}
 	$offset = $pageNumber * $pageSize;
+
+	$total = 0;
+	$totalRow = $db->get("SELECT COUNT(*) AS total FROM logs WHERE name = ?", $jobName);
+	if ($totalRow) {
+		$total = $totalRow["total"] + 0;
+	}
 
 	$job = array(
 		"jobName" => $jobName,
 		"pageNumber" => $pageNumber,
 		"pageSize" => $pageSize,
+		"total" => $total,
+		"firstRow" => $total > 0 ? $offset + 1 : 0,
+		"lastRow" => ($offset + $pageSize) < $total ? $offset + $pageSize : $total,
+		"hasPrev" => $pageNumber > 0,
+		"hasNext" => ($offset + $pageSize) < $total,
 		"link" => "/" . $jobName,
 	);
 
+	// Logs are numbered newest-first (row 1 = most recent) to stay consistent
+	// with the row lookup used by detail.php.
 	$logs = array();
-	$rows = $db->get_all("SELECT ID, stamp, duration, exitCode FROM (SELECT ROW_NUMBER() OVER (ORDER BY stamp DESC) AS ID, stamp, duration / 1000000000.0 AS duration, exit_code AS exitCode FROM logs WHERE name = ?) ORDER BY ID LIMIT ? OFFSET ?", $jobName, $pageSize, $offset);
+	$rows = $db->get_all("SELECT stamp, duration / 1000000000.0 AS duration, exit_code AS exitCode FROM logs WHERE name = ? ORDER BY stamp DESC LIMIT ? OFFSET ?", $jobName, $pageSize, $offset);
+	$rowNumber = $offset;
 	foreach ($rows as $log) {
+		$rowNumber++;
 		$exitCode = $log["exitCode"] + 0;
 		if ($exitCode != 0) {
-			$exitCode = '<span class="badge badge-danger">Exit: ' . $exitCode . '</span>';
+			$exitCode = '<span class="badge badge-fail">Exit: ' . $exitCode . '</span>';
 		} else {
-			$exitCode = '<span class="badge badge-success">OK</span>';
+			$exitCode = '<span class="badge badge-ok">OK</span>';
 		}
 		$logs[] = array(
-			"id" => $log["ID"],
-			"link" => $job["link"] . "/" . $log["ID"],
+			"id" => $rowNumber,
+			"link" => $job["link"] . "/" . $rowNumber,
 			"exitCode" => $exitCode,
 			"duration" => format_duration($log["duration"]),
 			"date" => date("Y/m/d H:i", strtotime($log["stamp"])),
@@ -71,7 +99,7 @@ if (isset($_PATH["jobName"]) && $_PATH["jobName"] != "") {
 		$monthly["datasets"][2]["data"][] = $row["durationMax"];
 	}
 
-	$title = $jobName . ", page " . $pageNumber;
+	$title = $jobName;
 
 	$tpl->load("job_stats.tpl");
 	$tpl->assign(array("title" => $title, "daily" => $daily, "monthly" => $monthly, "job" => $job, "logs" => $logs));

--- a/frontend/search.php
+++ b/frontend/search.php
@@ -6,7 +6,7 @@ include("bootstrap.php");
 
 $pageNumber = 0;
 if (isset($_POST["pageNumber"])) {
-	$pageNumber = $_POST["pageNumber"] + 0;
+	$pageNumber = (int)$_POST["pageNumber"];
 }
 $pageSize = 25;
 $offset = $pageNumber * $pageSize;

--- a/frontend/templates/cache/job_stats.tpl
+++ b/frontend/templates/cache/job_stats.tpl
@@ -2,6 +2,8 @@
 
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
 
 <div class="container">
 
@@ -13,8 +15,7 @@
 		</div>
 		<div class="page-actions">
 			<a class="btn btn-secondary" href="/">Dashboard</a>
-			<a class="btn btn-danger" href="/run/<?php echo $_v['job']['jobName'];?>
-">Run again</a>
+			<button class="btn btn-danger" type="button" onclick="runJob()">Run again</button>
 		</div>
 	</div>
 
@@ -84,17 +85,53 @@
 			</table>
 		</div>
 		<div class="pager">
+			<div class="pager__info">
+				<span id="pagerInfo"><?php if($_v['job']['total'] > 0){?>
+Showing <?php echo $_v['job']['firstRow'];?>
+&ndash;<?php echo $_v['job']['lastRow'];?>
+ of <?php echo $_v['job']['total']; }else{?>
+No runs recorded<?php }?></span>
+				<label class="pager__size">
+					Per page
+					<select id="pageSizeSelect" class="form-control" onchange="changePageSize(this.value)">
+						<option value="20" <?php if($_v['job']['pageSize'] == 20){?>
+selected<?php }?>>20</option>
+						<option value="50" <?php if($_v['job']['pageSize'] == 50){?>
+selected<?php }?>>50</option>
+						<option value="100" <?php if($_v['job']['pageSize'] == 100){?>
+selected<?php }?>>100</option>
+					</select>
+				</label>
+			</div>
 			<div class="page-actions">
-				<a id="linkPrevious" class="btn btn-secondary" href="<?php echo $_v['job']['link'];?>
+				<a id="linkPrevious" class="btn btn-secondary <?php if(!$_v['job']['hasPrev']){?>
+is-disabled<?php }?>" href="<?php echo $_v['job']['link'];?>
 ?pageNumber=<?php echo $_v['job']['pageNumber']-1;?>
-" <?php if($_v['job']['pageNumber'] == 0){?>
+&pageSize=<?php echo $_v['job']['pageSize'];?>
+" <?php if(!$_v['job']['hasPrev']){?>
 onclick="return false;"<?php }?>>&larr; Previous</a>
-				<a id="linkNext" class="btn btn-secondary" href="<?php echo $_v['job']['link'];?>
+				<a id="linkNext" class="btn btn-secondary <?php if(!$_v['job']['hasNext']){?>
+is-disabled<?php }?>" href="<?php echo $_v['job']['link'];?>
 ?pageNumber=<?php echo $_v['job']['pageNumber']+1;?>
-">Next &rarr;</a>
+&pageSize=<?php echo $_v['job']['pageSize'];?>
+" <?php if(!$_v['job']['hasNext']){?>
+onclick="return false;"<?php }?>>Next &rarr;</a>
 			</div>
 		</div>
 	</section>
+</div>
+
+<div id="termModal" class="modal-overlay" hidden>
+	<div class="modal modal--wide">
+		<div class="modal__head">
+			<span>Run <code><?php echo htmlspecialchars($_v['job']['jobName'], ENT_QUOTES);?>
+</code></span>
+			<button class="icon-btn" type="button" onclick="closeTerm()" aria-label="Close">&times;</button>
+		</div>
+		<div class="modal__body">
+			<div id="terminal" class="terminal-box"></div>
+		</div>
+	</div>
 </div>
 
 <script>
@@ -137,13 +174,50 @@ searchTextbox.addEventListener("keyup", function(event) {
 	var linkPrevious = document.getElementById("linkPrevious");
 	linkPrevious.href = "<?php echo $_v['job']['link'];?>
 ?pageNumber=<?php echo $_v['job']['pageNumber']-1;?>
+&pageSize=<?php echo $_v['job']['pageSize'];?>
 ";
 
 	var linkNext = document.getElementById("linkNext");
 	linkNext.href="<?php echo $_v['job']['link'];?>
 ?pageNumber=<?php echo $_v['job']['pageNumber']+1;?>
+&pageSize=<?php echo $_v['job']['pageSize'];?>
 ";
   }
+});
+
+function changePageSize(size) {
+	window.location.href = "<?php echo $_v['job']['link'];?>
+?pageNumber=0&pageSize=" + size;
+}
+
+// Run again: open a non-interactive terminal streamed over a websocket.
+var _termWs = null;
+function runJob() {
+	var overlay = document.getElementById('termModal');
+	var host = document.getElementById('terminal');
+	host.innerHTML = '';
+	overlay.hidden = false;
+
+	var term = new Terminal({ convertEol: true, fontSize: 13, cursorBlink: false, theme: { background: '#0b1120', foreground: '#e2e8f0' } });
+	term.open(host);
+	term.write('Connecting…\r\n');
+
+	var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+	var ws = new WebSocket(proto + '//' + window.location.host + '/ws/run/' + encodeURI("<?php echo $_v['job']['jobName'];?>
+"));
+	_termWs = ws;
+	ws.onmessage = function (event) { term.write(event.data); };
+	ws.onclose = function () { term.write('\r\n[session closed]\r\n'); };
+	ws.onerror = function () { term.write('\r\n[connection error]\r\n'); };
+}
+
+function closeTerm() {
+	if (_termWs) { _termWs.close(); _termWs = null; }
+	document.getElementById('termModal').hidden = true;
+}
+
+document.addEventListener('keydown', function (event) {
+	if (event.key === 'Escape') { closeTerm(); }
 });
 
 // search

--- a/frontend/templates/cache/main.tpl
+++ b/frontend/templates/cache/main.tpl
@@ -77,9 +77,21 @@ var sparkOptions = {
 				<?php if($_v['job']['active'] == 1 && strpos($_v['job']['name'], "onetime/") !== false){?>
 
 				<tr>
-					<td class="job-name"><a href="/<?php echo $_v['job']['name'];?>
+					<td class="job-name">
+						<div class="job-name__row">
+							<a href="/<?php echo $_v['job']['name'];?>
 "><code><?php echo $_v['job']['name'];?>
-</code></a></td>
+</code></a>
+							<button class="icon-btn" type="button" title="Edit description" data-name="<?php echo htmlspecialchars($_v['job']['name'], ENT_QUOTES);?>
+" data-desc="<?php echo htmlspecialchars($_v['job']['description'], ENT_QUOTES);?>
+" onclick="openDescModal(this)" aria-label="Edit description">
+								<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>
+							</button>
+						</div>
+						<?php if(!empty($_v['job']['description'])){?>
+<div class="job-desc"><?php echo htmlspecialchars($_v['job']['description'], ENT_QUOTES);?>
+</div><?php }?>
+					</td>
 					<?php if(!empty($_v['job']['lastRun'])){?>
 
 					<td><?php if($_v['job']['lastRun']['exitCode'] == 0){?>
@@ -137,9 +149,21 @@ stroke="#dc2626" fill="rgba(220,38,38,0.12)"<?php }?>></svg>
 				<?php if($_v['job']['active'] == 1 && strpos($_v['job']['name'], "onetime/") === false){?>
 
 				<tr>
-					<td class="job-name"><a href="/<?php echo $_v['job']['name'];?>
+					<td class="job-name">
+						<div class="job-name__row">
+							<a href="/<?php echo $_v['job']['name'];?>
 "><code><?php echo $_v['job']['name'];?>
-</code></a></td>
+</code></a>
+							<button class="icon-btn" type="button" title="Edit description" data-name="<?php echo htmlspecialchars($_v['job']['name'], ENT_QUOTES);?>
+" data-desc="<?php echo htmlspecialchars($_v['job']['description'], ENT_QUOTES);?>
+" onclick="openDescModal(this)" aria-label="Edit description">
+								<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>
+							</button>
+						</div>
+						<?php if(!empty($_v['job']['description'])){?>
+<div class="job-desc"><?php echo htmlspecialchars($_v['job']['description'], ENT_QUOTES);?>
+</div><?php }?>
+					</td>
 					<?php if(!empty($_v['job']['lastRun'])){?>
 
 					<td><?php if($_v['job']['lastRun']['exitCode'] == 0){?>
@@ -178,6 +202,67 @@ stroke="#dc2626" fill="rgba(220,38,38,0.12)"<?php }?>></svg>
 	</section>
 
 </div>
+
+<div id="descModal" class="modal-overlay" hidden>
+	<div class="modal">
+		<div class="modal__head">
+			<span>Edit description</span>
+			<button class="icon-btn" type="button" onclick="closeDescModal()" aria-label="Close">&times;</button>
+		</div>
+		<div class="modal__body">
+			<div class="modal__label" id="descJobName"></div>
+			<textarea id="descText" class="form-control" rows="4" placeholder="Describe what this job does…"></textarea>
+			<div id="descError" class="alert alert-danger" hidden></div>
+		</div>
+		<div class="modal__foot">
+			<button class="btn btn-secondary" type="button" onclick="closeDescModal()">Cancel</button>
+			<button class="btn btn-primary" type="button" onclick="saveDesc()">Save</button>
+		</div>
+	</div>
+</div>
+
+<script>
+var descName = null;
+
+function openDescModal(btn) {
+	descName = btn.getAttribute('data-name');
+	document.getElementById('descJobName').textContent = descName;
+	document.getElementById('descText').value = btn.getAttribute('data-desc') || '';
+	var err = document.getElementById('descError');
+	err.hidden = true;
+	err.textContent = '';
+	document.getElementById('descModal').hidden = false;
+	document.getElementById('descText').focus();
+}
+
+function closeDescModal() {
+	document.getElementById('descModal').hidden = true;
+}
+
+function showDescError(msg) {
+	var err = document.getElementById('descError');
+	err.textContent = msg;
+	err.hidden = false;
+}
+
+function saveDesc() {
+	if (!descName) { return; }
+	var body = new FormData();
+	body.append('name', descName);
+	body.append('description', document.getElementById('descText').value);
+	fetch('/description', { method: 'POST', body: body })
+		.then(function (r) { return r.json(); })
+		.then(function (data) {
+			if (data && data.ok) { location.reload(); }
+			else { showDescError((data && data.err) || 'Save failed'); }
+		})
+		.catch(function () { showDescError('Network error'); });
+}
+
+document.addEventListener('keydown', function (event) {
+	if (event.key === 'Escape') { closeDescModal(); }
+});
+</script>
 
 <?php $this->push();$this->load("html_footer.tpl");$this->assign($_v);$this->render();$this->pop();?>
 

--- a/frontend/templates/job_stats.tpl
+++ b/frontend/templates/job_stats.tpl
@@ -1,6 +1,8 @@
 {load html_header.tpl}
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
 
 <div class="container">
 
@@ -11,7 +13,7 @@
 		</div>
 		<div class="page-actions">
 			<a class="btn btn-secondary" href="/">Dashboard</a>
-			<a class="btn btn-danger" href="/run/{job.jobName}">Run again</a>
+			<button class="btn btn-danger" type="button" onclick="runJob()">Run again</button>
 		</div>
 	</div>
 
@@ -75,12 +77,35 @@
 			</table>
 		</div>
 		<div class="pager">
+			<div class="pager__info">
+				<span id="pagerInfo">{if $job['total'] > 0}Showing {job.firstRow}&ndash;{job.lastRow} of {job.total}{else}No runs recorded{/if}</span>
+				<label class="pager__size">
+					Per page
+					<select id="pageSizeSelect" class="form-control" onchange="changePageSize(this.value)">
+						<option value="20" {if $job['pageSize'] == 20}selected{/if}>20</option>
+						<option value="50" {if $job['pageSize'] == 50}selected{/if}>50</option>
+						<option value="100" {if $job['pageSize'] == 100}selected{/if}>100</option>
+					</select>
+				</label>
+			</div>
 			<div class="page-actions">
-				<a id="linkPrevious" class="btn btn-secondary" href="{job.link}?pageNumber={$job['pageNumber']-1}" {if $job['pageNumber'] == 0}onclick="return false;"{/if}>&larr; Previous</a>
-				<a id="linkNext" class="btn btn-secondary" href="{job.link}?pageNumber={$job['pageNumber']+1}">Next &rarr;</a>
+				<a id="linkPrevious" class="btn btn-secondary {if !$job['hasPrev']}is-disabled{/if}" href="{job.link}?pageNumber={$job['pageNumber']-1}&pageSize={job.pageSize}" {if !$job['hasPrev']}onclick="return false;"{/if}>&larr; Previous</a>
+				<a id="linkNext" class="btn btn-secondary {if !$job['hasNext']}is-disabled{/if}" href="{job.link}?pageNumber={$job['pageNumber']+1}&pageSize={job.pageSize}" {if !$job['hasNext']}onclick="return false;"{/if}>Next &rarr;</a>
 			</div>
 		</div>
 	</section>
+</div>
+
+<div id="termModal" class="modal-overlay" hidden>
+	<div class="modal modal--wide">
+		<div class="modal__head">
+			<span>Run <code>{$job['jobName']|escape}</code></span>
+			<button class="icon-btn" type="button" onclick="closeTerm()" aria-label="Close">&times;</button>
+		</div>
+		<div class="modal__body">
+			<div id="terminal" class="terminal-box"></div>
+		</div>
+	</div>
 </div>
 
 <script>
@@ -119,11 +144,44 @@ searchTextbox.addEventListener("keyup", function(event) {
   }
   if (searchTextbox.value.length == 0) {
 	var linkPrevious = document.getElementById("linkPrevious");
-	linkPrevious.href = "{job.link}?pageNumber={$job['pageNumber']-1}";
+	linkPrevious.href = "{job.link}?pageNumber={$job['pageNumber']-1}&pageSize={job.pageSize}";
 
 	var linkNext = document.getElementById("linkNext");
-	linkNext.href="{job.link}?pageNumber={$job['pageNumber']+1}";
+	linkNext.href="{job.link}?pageNumber={$job['pageNumber']+1}&pageSize={job.pageSize}";
   }
+});
+
+function changePageSize(size) {
+	window.location.href = "{job.link}?pageNumber=0&pageSize=" + size;
+}
+
+// Run again: open a non-interactive terminal streamed over a websocket.
+var _termWs = null;
+function runJob() {
+	var overlay = document.getElementById('termModal');
+	var host = document.getElementById('terminal');
+	host.innerHTML = '';
+	overlay.hidden = false;
+
+	var term = new Terminal({ convertEol: true, fontSize: 13, cursorBlink: false, theme: { background: '#0b1120', foreground: '#e2e8f0' } });
+	term.open(host);
+	term.write('Connecting…\r\n');
+
+	var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+	var ws = new WebSocket(proto + '//' + window.location.host + '/ws/run/' + encodeURI("{$job['jobName']}"));
+	_termWs = ws;
+	ws.onmessage = function (event) { term.write(event.data); };
+	ws.onclose = function () { term.write('\r\n[session closed]\r\n'); };
+	ws.onerror = function () { term.write('\r\n[connection error]\r\n'); };
+}
+
+function closeTerm() {
+	if (_termWs) { _termWs.close(); _termWs = null; }
+	document.getElementById('termModal').hidden = true;
+}
+
+document.addEventListener('keydown', function (event) {
+	if (event.key === 'Escape') { closeTerm(); }
 });
 
 // search

--- a/frontend/templates/main.tpl
+++ b/frontend/templates/main.tpl
@@ -70,7 +70,15 @@ var sparkOptions = {
 			{foreach $body['jobs'] as $k => $job}
 				{if $job['active'] == 1 && strpos($job['name'], "onetime/") !== false}
 				<tr>
-					<td class="job-name"><a href="/{$job['name']}"><code>{$job['name']}</code></a></td>
+					<td class="job-name">
+						<div class="job-name__row">
+							<a href="/{$job['name']}"><code>{$job['name']}</code></a>
+							<button class="icon-btn" type="button" title="Edit description" data-name="{$job['name']|escape}" data-desc="{$job['description']|escape}" onclick="openDescModal(this)" aria-label="Edit description">
+								<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>
+							</button>
+						</div>
+						{if !empty($job['description'])}<div class="job-desc">{$job['description']|escape}</div>{/if}
+					</td>
 					{if !empty($job['lastRun'])}
 					<td>{if $job['lastRun']['exitCode'] == 0}<span class="badge badge-ok">OK</span>{else}<span class="badge badge-fail">Exit: {$job['lastRun']['exitCode']}</span>{/if}</td>
 					<td>
@@ -114,7 +122,15 @@ var sparkOptions = {
 			{foreach $body['jobs'] as $k => $job}
 				{if $job['active'] == 1 && strpos($job['name'], "onetime/") === false}
 				<tr>
-					<td class="job-name"><a href="/{$job['name']}"><code>{$job['name']}</code></a></td>
+					<td class="job-name">
+						<div class="job-name__row">
+							<a href="/{$job['name']}"><code>{$job['name']}</code></a>
+							<button class="icon-btn" type="button" title="Edit description" data-name="{$job['name']|escape}" data-desc="{$job['description']|escape}" onclick="openDescModal(this)" aria-label="Edit description">
+								<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>
+							</button>
+						</div>
+						{if !empty($job['description'])}<div class="job-desc">{$job['description']|escape}</div>{/if}
+					</td>
 					{if !empty($job['lastRun'])}
 					<td>{if $job['lastRun']['exitCode'] == 0}<span class="badge badge-ok">OK</span>{else}<span class="badge badge-fail">Exit: {$job['lastRun']['exitCode']}</span>{/if}</td>
 					<td>
@@ -140,5 +156,66 @@ var sparkOptions = {
 	</section>
 
 </div>
+
+<div id="descModal" class="modal-overlay" hidden>
+	<div class="modal">
+		<div class="modal__head">
+			<span>Edit description</span>
+			<button class="icon-btn" type="button" onclick="closeDescModal()" aria-label="Close">&times;</button>
+		</div>
+		<div class="modal__body">
+			<div class="modal__label" id="descJobName"></div>
+			<textarea id="descText" class="form-control" rows="4" placeholder="Describe what this job does…"></textarea>
+			<div id="descError" class="alert alert-danger" hidden></div>
+		</div>
+		<div class="modal__foot">
+			<button class="btn btn-secondary" type="button" onclick="closeDescModal()">Cancel</button>
+			<button class="btn btn-primary" type="button" onclick="saveDesc()">Save</button>
+		</div>
+	</div>
+</div>
+
+<script>
+var descName = null;
+
+function openDescModal(btn) {
+	descName = btn.getAttribute('data-name');
+	document.getElementById('descJobName').textContent = descName;
+	document.getElementById('descText').value = btn.getAttribute('data-desc') || '';
+	var err = document.getElementById('descError');
+	err.hidden = true;
+	err.textContent = '';
+	document.getElementById('descModal').hidden = false;
+	document.getElementById('descText').focus();
+}
+
+function closeDescModal() {
+	document.getElementById('descModal').hidden = true;
+}
+
+function showDescError(msg) {
+	var err = document.getElementById('descError');
+	err.textContent = msg;
+	err.hidden = false;
+}
+
+function saveDesc() {
+	if (!descName) { return; }
+	var body = new FormData();
+	body.append('name', descName);
+	body.append('description', document.getElementById('descText').value);
+	fetch('/description', { method: 'POST', body: body })
+		.then(function (r) { return r.json(); })
+		.then(function (data) {
+			if (data && data.ok) { location.reload(); }
+			else { showDescError((data && data.err) || 'Save failed'); }
+		})
+		.catch(function () { showDescError('Network error'); });
+}
+
+document.addEventListener('keydown', function (event) {
+	if (event.key === 'Escape') { closeDescModal(); }
+});
+</script>
 
 {load html_footer.tpl}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/titpetric/pdo v0.0.0-20260708190443-d44610ab0476
 	github.com/titpetric/phpscript v0.0.7
 	github.com/titpetric/platform v0.4.6
+	golang.org/x/net v0.56.0
 	modernc.org/sqlite v1.53.0
 )
 
@@ -43,7 +44,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260622175928-b703f567277d // indirect

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,17 +10,29 @@ import (
 )
 
 type Storage struct {
-	db *pdo.PDO
+	db     *pdo.PDO
+	handle *sqlx.DB
 }
 
 func NewStorage(handle *sqlx.DB) *Storage {
 	return &Storage{
-		db: pdo.New(handle),
+		db:     pdo.New(handle),
+		handle: handle,
 	}
 }
 
 func (s *Storage) SaveJob(ctx context.Context, name, description string) error {
 	now := time.Now()
+
+	// The config sync passes an empty description, so keep any existing
+	// (potentially user-edited) description instead of clobbering it on reload.
+	if description == "" {
+		var existing string
+		if err := s.handle.GetContext(ctx, &existing, "SELECT description FROM jobs WHERE name = ?", name); err == nil {
+			description = existing
+		}
+	}
+
 	job := model.Jobs{
 		Name:        name,
 		Description: description,

--- a/web/module.go
+++ b/web/module.go
@@ -3,11 +3,16 @@ package web
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"golang.org/x/net/websocket"
 
 	"github.com/titpetric/platform"
 
@@ -22,12 +27,15 @@ type Module struct {
 	platform.UnimplementedModule
 
 	root         string
+	scriptPath   string
 	includeCache *runner.IncludeCache
 	exprCache    *runner.ExprCache
 }
 
 // NewModule creates the web dashboard module rooted at the given directory.
-func NewModule(root string) *Module {
+// scriptPath is the directory holding the cron scripts, used by the live "run"
+// terminal endpoint.
+func NewModule(root, scriptPath string) *Module {
 	// Bridge the platform DB env (PLATFORM_DB_CRONTAB) to the phpscript
 	// DatabaseDriver env (DB_DSN_CRONTAB) so PHP can open the same database.
 	if dsn := os.Getenv("PLATFORM_DB_CRONTAB"); dsn != "" && os.Getenv("DB_DSN_CRONTAB") == "" {
@@ -37,6 +45,7 @@ func NewModule(root string) *Module {
 	return &Module{
 		UnimplementedModule: *platform.NewUnimplementedModule("web"),
 		root:                root,
+		scriptPath:          scriptPath,
 		includeCache:        runner.NewIncludeCache(),
 		exprCache:           runner.NewExprCache(),
 	}
@@ -56,11 +65,71 @@ func (m *Module) Mount(ctx context.Context, r platform.Router) error {
 	}
 
 	r.Get("/assets/*", m.handleStatic)
+	r.Handle("/ws/run/*", websocket.Handler(m.handleRunWS))
 	r.Handle("/*", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		phpMux.ServeHTTP(w, r)
 	}))
 	return nil
+}
+
+// handleRunWS runs a cron script on demand and streams its combined output to
+// the browser over a websocket, so the dashboard can render it in an xterm.js
+// terminal. The run is non-interactive: no stdin is forwarded.
+func (m *Module) handleRunWS(ws *websocket.Conn) {
+	defer ws.Close()
+
+	// Send output as text frames so the browser receives strings directly.
+	ws.PayloadType = websocket.TextFrame
+
+	// Resolve the requested job name from the path and guard against traversal.
+	name := strings.TrimPrefix(ws.Request().URL.Path, "/ws/run/")
+	name = strings.TrimPrefix(path.Clean("/"+name), "/")
+	if name == "" || strings.Contains(name, "..") {
+		io.WriteString(ws, "invalid job name\r\n")
+		return
+	}
+
+	script := filepath.Join(m.scriptPath, filepath.FromSlash(name))
+	absRoot, err := filepath.Abs(m.scriptPath)
+	if err != nil {
+		io.WriteString(ws, "server error\r\n")
+		return
+	}
+	absScript, err := filepath.Abs(script)
+	if err != nil || !strings.HasPrefix(absScript, absRoot+string(os.PathSeparator)) {
+		io.WriteString(ws, "invalid job path\r\n")
+		return
+	}
+	if _, err := os.Stat(script); err != nil {
+		fmt.Fprintf(ws, "script not found: %s\r\n", name)
+		return
+	}
+
+	fmt.Fprintf(ws, "$ ./%s\r\n", name)
+
+	cmd := exec.Command("./" + name)
+	cmd.Dir = m.scriptPath
+	cmd.Env = append(os.Environ(), "TERM=xterm")
+
+	// A single pipe fed by both stdout and stderr keeps their writes ordered
+	// and safe for the copying goroutine (io.PipeWriter is concurrency-safe).
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(ws, "failed to start: %s\r\n", err)
+		return
+	}
+
+	go func() {
+		_ = cmd.Wait()
+		_ = pw.Close()
+	}()
+
+	_, _ = io.Copy(ws, pr)
+	io.WriteString(ws, "\r\n[process finished]\r\n")
 }
 
 // handleStatic serves static assets (CSS, JS) from the frontend root.


### PR DESCRIPTION
## Summary

- **Fix broken pagination.** `$_GET/$_POST/$_PATH` values were coerced with `+ 0`, but phpscript rejects `string + int`, so pages 2+ and every log detail page returned a 500. Switched to explicit `(int)` casts in `index.php`, `search.php`, and `detail.php`, and rewrote the history query to a plain `ORDER BY stamp DESC LIMIT ? OFFSET ?` with row numbers computed in PHP (kept consistent with `detail.php`'s newest-first numbering).
- **Per-page selector.** Added a 20/50/100 selector and a "Showing X–Y of Z" summary; Previous/Next are disabled at the ends and carry the page size.
- **Job heading.** Dropped the `, page N` suffix.
- **Editable descriptions.** Added an inline edit icon + modal on the dashboard that saves through a new `POST /description` endpoint. `Storage.SaveJob` now preserves an existing description when the config sync passes an empty one, so edits survive restarts.
- **Run again → live terminal.** Replaced the `/run/<job>` link with an xterm.js terminal that streams a non-interactive run over a new `/ws/run/<job>` websocket endpoint (with path-traversal guards), inspired by titpetric/task-ui.
- **Log whitespace.** Moved `white-space: pre-wrap` onto individual log lines to remove the blank gaps between output rows.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass.
- [x] `?pageNumber=1&pageSize=20` returns 200 with rows 21–40 (previously 500/empty).
- [x] `pageSize=50/100` selector works and persists the selection.
- [x] `POST /description` returns `{"ok":true}`, renders on the dashboard, and survives a server restart.
- [x] `/ws/run/<job>` handshake is wired (scripts execute on the Linux/Docker deploy).
- [ ] Reviewer: confirm websocket run streaming in a Linux deployment.

Made with [Cursor](https://cursor.com)